### PR TITLE
ci: Use a better action for the analyze step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,27 +33,11 @@ jobs:
     - name: Install dependencies
       run: flutter pub get
 
-    # Analyze step needs different config for pull_request and push, so it is
-    # duplicated with if conditions to use the correct configuration for each
-    - name: Analyze (push)
-      if: github.event_name == 'push' && matrix.test_type == 'static'
-      uses: kitek/dartanalyzer-annotations-action@v1
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+    - name: Analyze
+      if: matrix.test_type == 'static'
+      uses: zgosalvez/github-actions-analyze-flutter@v1
       with:
-        check_name: test
-        commit_sha: ${{ github.sha }}
-    - name: Analyze (pull_request)
-      if: github.event_name == 'pull_request' && matrix.test_type == 'static'
-      uses: kitek/dartanalyzer-annotations-action@v1
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      with:
-        check_name: test
-        commit_sha: ${{ github.event.pull_request.head.sha }}
-
-    - name: Check format
-      run: flutter format -n --set-exit-if-changed lib test example
+        fail-on-warnings: true
 
     - name: Run ${{ matrix.test_type }} tests
       if: matrix.test_type != 'static'


### PR DESCRIPTION
Replace kitek/dartanalyzer-annotations-action@v1 with zgosalvez/github-actions-analyze-flutter@v1 which don't need different configurations for push and pull_request and includes format check too.
