### PR TITLE
workflows/pub-score: Remove container hack

### DIFF
--- a/.github/workflows/pub-score.yml
+++ b/.github/workflows/pub-score.yml
@@ -8,15 +8,14 @@ on:
 jobs:
   pub-score:
     runs-on: ubuntu-latest
-    container: axelop/dart_package_analyzer:v3
     steps:
       - uses: actions/checkout@v2
 
       - name: Dart Package Analyzer
+        uses: axel-op/dart-package-analyzer@v3
         id: score
-        env:
-          INPUT_GITHUBTOKEN: ${{ github.token }}
-        run: /dart_package_analyzer
+        with:
+          githubToken: ${{ github.token }}
 
       - name: Check score
         env:


### PR DESCRIPTION
This hack was necessary to use custom credentials, but this is not needed anymore, so we can use the regular action.
