### PR TITLE
Bump example minimum SDK API to 23

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -39,7 +39,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.example"
-        minSdkVersion 16
+        minSdkVersion 23
         targetSdkVersion 29
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
This is needed by the audioplayers plugin and it should have been done in e65a900db0b90ab5d7793ffea299bfcaddd302d7 but it was, unfortunatelly, overlooked.